### PR TITLE
Use Tox for running the tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements_dev.txt
 
-    - name: Test with unittest
+    - name: Test with Tox
       run: |
-        python -m unittest --buffer
+        tox -e py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-cookiecutter
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+    py{36,37,38}
+skipsdist = true
+skip_missing_interpreters = true
+
+[testenv]
+deps = cookiecutter
+commands = python -m unittest discover --buffer


### PR DESCRIPTION
By using Tox, all test dependencies can be specified in the tox.ini
configuration. Running the tests can then be done by executing `tox`,
this also works in CI.