### PR TITLE
Add Python 3.9 and Python 3.10 to Tox env list

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}
+    py{36,37,38,39,310}
     lint
 skipsdist = true
 skip_missing_interpreters = true

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    py{36,37,38}
+    py{36,37,38,39,310}
     lint
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Support Python 3.9 and Python 3.10 by including those versions in the
test configuration. This means adding it to the environment list of Tox,
and specifying these versions in the CI configuration.

The Python versions in the CI configuration are now quoted, because
otherwise version 3.10 is interpreter as 3.1.