### PR TITLE
Do not cancel GitHub workflow after failure

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The default strategy is "fail-fast", which means that as soon as one
step fails, all the others are canceled. This behavior is not desirable
in this case, because a test might fail for one Python version but not
the others.