### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}
+    py{37,38,39,310}
     lint
 skipsdist = true
 skip_missing_interpreters = true

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    py{36,37,38,39,310}
+    py{37,38,39,310}
     lint
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Python 3.6 has reached its end-of-life status on 2021-12-23, and should therefore no longer be supported by this template.